### PR TITLE
Bumping package version after a dependabot upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "nyc --reporter=lcov --reporter=text-summary mocha",
     "test-server": "node ./test/integration/test-server.js"
   },
-  "version": "2.2.1",
+  "version": "2.2.2",
   "dependencies": {
     "async": "*2.6.4",
     "aws-sdk": "^2.1141.0",


### PR DESCRIPTION
I merged a dependabot PR, but forgot to manually go in and bump the version in `package.json`.  Seems as though the package is only auto-published when the version is bumped.